### PR TITLE
reduce layers and image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM lscr.io/linuxserver/baseimage-ubuntu:bionic
 
-RUN apt-get update;
-RUN apt-get install --no-install-recommends --yes \
+RUN apt-get update && \
+    apt-get install --no-install-recommends --yes \
 	lighttpd \
-	nut-cgi;
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
+	nut-cgi && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
 
 # make backup of nut hosts file, so we can rebuild it each startup
 RUN mv /etc/nut/hosts.conf /etc/nut/hosts.conf.original

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Starting nut-cgi, build date $(cat /build-date.txt)"
-echo "${NUT_HOSTS}"
+echo "${NUT_HOSTS}" | awk '{ print $1" "$2" "$3 }'
 
 # setup list of monitored ups hosts
 cp /etc/nut/hosts.conf.original /etc/nut/hosts.conf


### PR DESCRIPTION
This PR reduces the layers of the image and also the size by ~60MB
Since the apt commands were in 3 different RUN steps they all added to the image size (also the rm command).
Putting all in one RUN cleans all up before creating the layer. 

Also the entrypoint is modified to not print user and passwords.